### PR TITLE
examples: drivers: gpio: gpio_led_blink: Modify the LED blink example

### DIFF
--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/example.syscfg
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/example.syscfg
@@ -1,0 +1,75 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM62x" --package "ALW" --part "Default" --context "m4fss0-0" --product "MCU_PLUS_SDK_AM62x@09.01.00"
+ * @versions {"tool":"1.18.0+3266"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const gpio            = scripting.addModule("/drivers/gpio/gpio", {}, false);
+const gpio1           = gpio.addInstance();
+const ipc             = scripting.addModule("/drivers/ipc/ipc");
+const addr_translate  = scripting.addModule("/kernel/dpl/addr_translate", {}, false);
+const addr_translate1 = addr_translate.addInstance();
+const addr_translate2 = addr_translate.addInstance();
+const addr_translate3 = addr_translate.addInstance();
+const addr_translate4 = addr_translate.addInstance();
+const addr_translate5 = addr_translate.addInstance();
+const clock           = scripting.addModule("/kernel/dpl/clock");
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+gpio1.pinDir                   = "OUTPUT";
+gpio1.$name                    = "GPIO_LED";
+gpio1.MCU_GPIO.$assign         = "MCU_GPIO0";
+gpio1.MCU_GPIO.gpioPin.$assign = "MCU_SPI0_CS0";
+
+ipc.r5fss0_0 = "NONE";
+ipc.a53ss0_0 = "notify_rpmsg";
+
+addr_translate1.$name     = "CONFIG_ADDR_TRANSLATE_REGION0";
+addr_translate1.localAddr = 0x80000000;
+addr_translate1.size      = 28;
+
+addr_translate2.$name      = "CONFIG_ADDR_TRANSLATE_REGION1";
+addr_translate2.systemAddr = 0x20000000;
+addr_translate2.localAddr  = 0xA0000000;
+
+addr_translate3.$name      = "CONFIG_ADDR_TRANSLATE_REGION2";
+addr_translate3.systemAddr = 0x40000000;
+addr_translate3.localAddr  = 0xC0000000;
+
+addr_translate4.$name      = "CONFIG_ADDR_TRANSLATE_REGION3";
+addr_translate4.systemAddr = 0x60000000;
+addr_translate4.localAddr  = 0x60000000;
+
+addr_translate5.$name      = "CONFIG_ADDR_TRANSLATE_REGION4";
+addr_translate5.localAddr  = 0x90000000;
+addr_translate5.systemAddr = 0x90000000;
+addr_translate5.size       = 28;
+
+debug_log.enableUartLog            = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.MCU_UART.$assign = "MCU_USART0";
+
+mpu_armv71.$name        = "CONFIG_MPU_REGION0";
+mpu_armv71.attributes   = "Device";
+mpu_armv71.allowExecute = false;
+
+mpu_armv72.$name = "CONFIG_MPU_REGION1";
+mpu_armv72.size  = 18;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.MCU_UART.RXD.$suggestSolution = "MCU_UART0_RXD";
+debug_log.uartLog.MCU_UART.TXD.$suggestSolution = "MCU_UART0_TXD";

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/main.c
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void gpio_led_blink_main(void *args);
+
+void freertos_main(void *args)
+{
+    gpio_led_blink_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main()
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex M.AM62x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Gpio Led Blink"
+        name = "gpio_led_blink_phyboard-lyra-am62xx_m4fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.MCU_PLUS_SDK_AM62X"
+        configurations="
+            Debug,
+            Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="2.1.3"
+        device="Cortex M.AM62x"
+        deviceCore="Cortex_M4F_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CM4F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am62x/m4f
+            -mcpu=cortex-m4
+            -mfloat-abi=hard
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM62X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=gpio_led_blink.${ConfigName}.map
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE}"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context m4fss0-0 --part Default --package ALW
+        "
+
+        description="A Gpio Led Blink FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am62x.m4f.ti-arm-clang.debug.lib
+                -ldrivers.am62x.m4f.ti-arm-clang.debug.lib
+                -lboard.am62x.m4f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am62x.m4f.ti-arm-clang.release.lib
+                -ldrivers.am62x.m4f.ti-arm-clang.release.lib
+                -lboard.am62x.m4f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM62X_INSTALL_DIR}" scope="project" />
+        <file path="../../../gpio_led_blink.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${MCU_PLUS_SDK_PATH}/docs/api_guide_am62x/EXAMPLES_DRIVERS_GPIO_LED_BLINK.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,62 @@
+
+/* make sure below retain is there in your linker command file, it keeps the vector table in the final binary */
+--retain="*(.vectors)"
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+
+
+SECTIONS
+{
+    /* This has the M4F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > M4F_VECS
+    .text:   {} palign(8) > M4F_IRAM     /* This is where code resides */
+
+    .bss:    {} palign(8) > M4F_DRAM     /* This is where uninitialized globals go */
+    RUN_START(__BSS_START)
+    RUN_END(__BSS_END)
+
+    .data:   {} palign(8) > M4F_DRAM     /* This is where initialized globals and static go */
+    .rodata: {} palign(8) > M4F_DRAM     /* This is where const's go */
+    .sysmem: {} palign(8) > M4F_IRAM     /* This is where the malloc heap goes */
+    .stack:  {} palign(8) > M4F_IRAM     /* This is where the main() stack goes */
+
+    GROUP {
+        /* This is the resource table used by linux to know where the IPC "VRINGs" are located */
+        .resource_table: {} palign(4096)
+    } > DDR_IPC_RESOURCE_TABLE_LINUX
+
+    /* Sections needed for C++ projects */
+    .ARM.exidx:     {} palign(8) > M4F_IRAM  /* Needed for C++ exception handling */
+    .init_array:    {} palign(8) > M4F_IRAM  /* Contains function pointers called before main */
+    .fini_array:    {} palign(8) > M4F_IRAM  /* Contains function pointers called after main */
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > DDR_IPC_VRING_RTOS
+}
+
+MEMORY
+{
+    M4F_VECS : ORIGIN = 0x00000000 , LENGTH = 0x00000200
+    M4F_IRAM : ORIGIN = 0x00000200 , LENGTH = 0x0002FE00
+    M4F_DRAM : ORIGIN = 0x00030000 , LENGTH = 0x00010000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with R5F's
+     */
+    /* Resource table must be placed at the start of DDR_IPC_RESOURCE_TABLE_LINUX when M4 core is early booting with Linux */
+    DDR_IPC_RESOURCE_TABLE_LINUX       : ORIGIN = 0x9CC00000 , LENGTH = 0x1000
+
+
+    DDR_IPC_VRING_RTOS: ORIGIN = 0x9C800000, LENGTH = 0x00300000
+}
+

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/makefile
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,305 @@
+#
+# Auto generated makefile
+#
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=gpio_led_blink.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=gpio_led_blink.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=gpio_led_blink.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=gpio_led_blink.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=gpio_led_blink.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=gpio_led_blink.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=gpio_led_blink.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=gpio_led_blink.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=gpio_led_blink.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	gpio_led_blink.c \
+	main.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CM4F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am62x/m4f \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM62X \
+
+CFLAGS_common := \
+	-mcpu=cortex-m4 \
+	-mfloat-abi=hard \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-deprecated-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	board.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am62x:m4fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am62x:m4fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+$(OUTNAME): syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+	@echo  .
+	@echo  Linking: am62x:m4fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	$(RM) am62-mcu-m4f0_0-fw
+	$(STRIP) -p $@ -o=am62-mcu-m4f0_0-fw
+	@echo  Linking: am62x:m4fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am62x:m4fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) am62-mcu-m4f0_0-fw
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am62x:m4fss0-0:freertos:ti-arm-clang gpio_led_blink ...
+	$(RMDIR) obj
+	$(RM) am62-mcu-m4f0_0-fw
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --context m4fss0-0 --part Default --package ALW --output generated/ ../example.syscfg
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --device AM62x --context m4fss0-0 --part Default --package ALW --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_a53ss0-1 = 1
+BOOTIMAGE_CORE_ID_a53ss1-0 = 2
+BOOTIMAGE_CORE_ID_a53ss1-1 = 3
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_m4fss0-0 = 5
+BOOTIMAGE_CORE_ID_hsm-m4fss0-0 = 6
+SBL_RUN_ADDRESS=0x43C00000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_m4fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_m4fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 2 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  .
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 2 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 2 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+endif
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,110 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_a53ss0-1 = 1
+BOOTIMAGE_CORE_ID_a53ss1-0 = 2
+BOOTIMAGE_CORE_ID_a53ss1-1 = 3
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_m4fss0-0 = 5
+BOOTIMAGE_CORE_ID_hsm-m4fss0-0 = 6
+SBL_RUN_ADDRESS=0x43C00000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_m4fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_m4fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(PROFILE)/am62-mcu-m4f0_0-fw
+	$(STRIP) -o=$(PROFILE)/am62-mcu-m4f0_0-fw $(OUTFILE)
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am62x:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=gpio_led_blink_phyboard-lyra-am62xx_m4fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(MCU_PLUS_SDK_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/example.syscfg
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/example.syscfg
@@ -1,0 +1,64 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM62x" --package "ALW" --part "Default" --context "m4fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.12.1+2446"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const gpio            = scripting.addModule("/drivers/gpio/gpio", {}, false);
+const gpio1           = gpio.addInstance();
+const addr_translate  = scripting.addModule("/kernel/dpl/addr_translate", {}, false);
+const addr_translate1 = addr_translate.addInstance();
+const addr_translate2 = addr_translate.addInstance();
+const addr_translate3 = addr_translate.addInstance();
+const addr_translate4 = addr_translate.addInstance();
+const clock           = scripting.addModule("/kernel/dpl/clock");
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+gpio1.pinDir                   = "OUTPUT";
+gpio1.$name                    = "GPIO_LED";
+gpio1.MCU_GPIO.$assign         = "MCU_GPIO0";
+gpio1.MCU_GPIO.gpioPin.$assign = "ball.A7";
+
+addr_translate1.$name     = "CONFIG_ADDR_TRANSLATE_REGION0";
+addr_translate1.localAddr = 0x80000000;
+
+addr_translate2.$name      = "CONFIG_ADDR_TRANSLATE_REGION1";
+addr_translate2.systemAddr = 0x20000000;
+addr_translate2.localAddr  = 0xA0000000;
+
+addr_translate3.$name      = "CONFIG_ADDR_TRANSLATE_REGION2";
+addr_translate3.systemAddr = 0x40000000;
+addr_translate3.localAddr  = 0xC0000000;
+
+addr_translate4.$name      = "CONFIG_ADDR_TRANSLATE_REGION3";
+addr_translate4.systemAddr = 0x60000000;
+addr_translate4.localAddr  = 0x60000000;
+
+debug_log.enableUartLog = true;
+debug_log.uartLog.$name = "CONFIG_UART0";
+
+mpu_armv71.$name        = "CONFIG_MPU_REGION0";
+mpu_armv71.attributes   = "Device";
+mpu_armv71.allowExecute = false;
+
+mpu_armv72.$name = "CONFIG_MPU_REGION1";
+mpu_armv72.size  = 18;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.MCU_UART.$suggestSolution     = "MCU_USART0";
+debug_log.uartLog.MCU_UART.RXD.$suggestSolution = "ball.B5";
+debug_log.uartLog.MCU_UART.TXD.$suggestSolution = "ball.A5";

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/main.c
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/main.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021 Texas Instruments Incorporated
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -30,44 +30,21 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <drivers/gpio.h>
-#include <kernel/dpl/AddrTranslateP.h>
-#include <kernel/dpl/DebugP.h>
-#include <kernel/dpl/ClockP.h>
+#include <stdlib.h>
 #include "ti_drivers_config.h"
-#include "ti_drivers_open_close.h"
-#include "ti_board_open_close.h"
+#include "ti_board_config.h"
 
-/*
- * This example configures a GPIO pin connected to an LED on the EVM in
- * output mode.
- * The application toggles the LED on/off for 10 seconds and exits.
- */
+void gpio_led_blink_main(void *args);
 
-void gpio_led_blink_main(void *args)
+int main()
 {
-    uint32_t    gpioBaseAddr, pinNum;
+    System_init();
+    Board_init();
 
-    DebugP_log("GPIO LED Blink Test Started ...\r\n");
+    gpio_led_blink_main(NULL);
 
-    /* Get address after translation translate */
-    gpioBaseAddr = (uint32_t) AddrTranslateP_getLocalAddr(GPIO_LED_BASE_ADDR);
-    pinNum       = GPIO_LED_PIN;
+    Board_deinit();
+    System_deinit();
 
-    GPIO_setDirMode(gpioBaseAddr, pinNum, GPIO_LED_DIR);
-    while(1)
-    {
-        GPIO_pinWriteHigh(gpioBaseAddr, pinNum);
-        ClockP_usleep(150000);
-        GPIO_pinWriteLow(gpioBaseAddr, pinNum);
-        ClockP_usleep(50000);
-        GPIO_pinWriteHigh(gpioBaseAddr, pinNum);
-        ClockP_usleep(150000);
-        GPIO_pinWriteLow(gpioBaseAddr, pinNum);
-        ClockP_sleep(1);
-    }
-
-    Board_driversClose();
-    Drivers_close();
+    return 0;
 }
-

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/example.projectspec
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/example.projectspec
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex M.AM62x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Gpio Led Blink"
+        name = "gpio_led_blink_phyboard-lyra-am62xx_m4fss0-0_nortos_ti-arm-clang"
+        products="sysconfig;com.ti.MCU_PLUS_SDK_AM62X"
+        configurations="
+            Debug,
+            Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="2.1.3"
+        device="Cortex M.AM62x"
+        deviceCore="Cortex_M4F_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -mcpu=cortex-m4
+            -mfloat-abi=hard
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM62X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/nortos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=gpio_led_blink.${ConfigName}.map
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE}"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context m4fss0-0 --part Default --package ALW
+        "
+
+        description="A Gpio Led Blink NORTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lnortos.am62x.m4f.ti-arm-clang.debug.lib
+                -ldrivers.am62x.m4f.ti-arm-clang.debug.lib
+                -lboard.am62x.m4f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lnortos.am62x.m4f.ti-arm-clang.release.lib
+                -ldrivers.am62x.m4f.ti-arm-clang.release.lib
+                -lboard.am62x.m4f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM62X_INSTALL_DIR}" scope="project" />
+        <file path="../../../gpio_led_blink.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${MCU_PLUS_SDK_PATH}/docs/api_guide_am62x/EXAMPLES_DRIVERS_GPIO_LED_BLINK.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/linker.cmd
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/linker.cmd
@@ -1,0 +1,62 @@
+
+/* make sure below retain is there in your linker command file, it keeps the vector table in the final binary */
+--retain="*(.vectors)"
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+
+
+SECTIONS
+{
+    /* This has the M4F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > M4F_VECS
+    .text:   {} palign(8) > M4F_IRAM     /* This is where code resides */
+
+    .bss:    {} palign(8) > M4F_DRAM     /* This is where uninitialized globals go */
+    RUN_START(__BSS_START)
+    RUN_END(__BSS_END)
+
+    .data:   {} palign(8) > M4F_DRAM     /* This is where initialized globals and static go */
+    .rodata: {} palign(8) > M4F_DRAM     /* This is where const's go */
+    .sysmem: {} palign(8) > M4F_IRAM     /* This is where the malloc heap goes */
+    .stack:  {} palign(8) > M4F_IRAM     /* This is where the main() stack goes */
+
+    GROUP {
+        /* This is the resource table used by linux to know where the IPC "VRINGs" are located */
+        .resource_table: {} palign(4096)
+    } > DDR_IPC_RESOURCE_TABLE_LINUX
+
+    /* Sections needed for C++ projects */
+    .ARM.exidx:     {} palign(8) > M4F_IRAM  /* Needed for C++ exception handling */
+    .init_array:    {} palign(8) > M4F_IRAM  /* Contains function pointers called before main */
+    .fini_array:    {} palign(8) > M4F_IRAM  /* Contains function pointers called after main */
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > DDR_IPC_VRING_RTOS
+}
+
+MEMORY
+{
+    M4F_VECS : ORIGIN = 0x00000000 , LENGTH = 0x00000200
+    M4F_IRAM : ORIGIN = 0x00000200 , LENGTH = 0x0002FE00
+    M4F_DRAM : ORIGIN = 0x00030000 , LENGTH = 0x00010000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with R5F's
+     */
+    /* Resource table must be placed at the start of DDR_IPC_RESOURCE_TABLE_LINUX when M4 core is early booting with Linux */
+    DDR_IPC_RESOURCE_TABLE_LINUX       : ORIGIN = 0x9CC00000 , LENGTH = 0x1000
+
+
+    DDR_IPC_VRING_RTOS: ORIGIN = 0x9C800000, LENGTH = 0x00300000
+}
+

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/makefile
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/makefile
@@ -1,0 +1,302 @@
+#
+# Auto generated makefile
+#
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=gpio_led_blink.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=gpio_led_blink.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=gpio_led_blink.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=gpio_led_blink.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=gpio_led_blink.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=gpio_led_blink.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=gpio_led_blink.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=gpio_led_blink.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=gpio_led_blink.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	gpio_led_blink.c \
+	main.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM62X \
+
+CFLAGS_common := \
+	-mcpu=cortex-m4 \
+	-mfloat-abi=hard \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-deprecated-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/nortos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lnortos.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	nortos.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	board.am62x.m4f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/nortos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am62x:m4fss0-0:nortos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am62x:m4fss0-0:nortos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+$(OUTNAME): syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+	@echo  .
+	@echo  Linking: am62x:m4fss0-0:nortos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	$(RM) am62-mcu-m4f0_0-fw
+	$(STRIP) -p $@ -o=am62-mcu-m4f0_0-fw
+	@echo  Linking: am62x:m4fss0-0:nortos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am62x:m4fss0-0:nortos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) am62-mcu-m4f0_0-fw
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am62x:m4fss0-0:nortos:ti-arm-clang gpio_led_blink ...
+	$(RMDIR) obj
+	$(RM) am62-mcu-m4f0_0-fw
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --context m4fss0-0 --part Default --package ALW --output generated/ ../example.syscfg
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --device AM62x --context m4fss0-0 --part Default --package ALW --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_a53ss0-1 = 1
+BOOTIMAGE_CORE_ID_a53ss1-0 = 2
+BOOTIMAGE_CORE_ID_a53ss1-1 = 3
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_m4fss0-0 = 5
+BOOTIMAGE_CORE_ID_hsm-m4fss0-0 = 6
+SBL_RUN_ADDRESS=0x43C00000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_m4fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_m4fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 2 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  .
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 2 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 2 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+endif
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,110 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_a53ss0-1 = 1
+BOOTIMAGE_CORE_ID_a53ss1-0 = 2
+BOOTIMAGE_CORE_ID_a53ss1-1 = 3
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_m4fss0-0 = 5
+BOOTIMAGE_CORE_ID_hsm-m4fss0-0 = 6
+SBL_RUN_ADDRESS=0x43C00000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_m4fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_m4fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(PROFILE)/am62-mcu-m4f0_0-fw
+	$(STRIP) -o=$(PROFILE)/am62-mcu-m4f0_0-fw $(OUTFILE)
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am62x:m4fss0-0:nortos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/makefile_projectspec
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export MCU_PLUS_SDK_PATH?=$(abspath ../../../../../../..)
+include $(MCU_PLUS_SDK_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=gpio_led_blink_phyboard-lyra-am62xx_m4fss0-0_nortos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(MCU_PLUS_SDK_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(MCU_PLUS_SDK_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/drivers/gpio/gpio_led_blink/phyboard-lyra-am62xx/m4fss0-0_nortos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];


### PR DESCRIPTION
Create a modified version of the GPIO LED blink example for phyboard lyra am62xx machine. There are changes to the linker command and sysconfig files to enable IPC with Linux, and the LED now does a heartbeat indefinitely.

Only the m4 core examples have been adapted.